### PR TITLE
How much of the test suite passes on PyBaMM wheels?

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -1,0 +1,39 @@
+name: PyBaMM wheel tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+env:
+  FORCE_COLOR: 3
+
+jobs:
+  run_unit_tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11"]
+    name: test-suite-${{ matrix.os }}-pybamm-24.1-${{ matrix.python-version }}
+
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install PyBaMM via wheels
+        run: python -m pip install "pybamm[all,jax,dev]==24.1"
+
+      - name: Checkout tests from PyBaMM repository
+        uses: actions/checkout@v4
+        with:
+          repository: pybamm-team/PyBaMM
+          ref: 'v24.1'
+          sparse-checkout: |
+            tests
+          sparse-checkout-cone-mode: true
+
+      - name: Run unit tests and integration tests with unittest
+        run: python -m unittest discover -s tests --verbose


### PR DESCRIPTION
To answer the question on pybamm-team/PyBaMM#3783: this PR has been opened on my fork to debug the IDAKLU solver on CI providers, which we currently don't do on Windows for PR tests on the upstream PyBaMM repository.